### PR TITLE
Security hardening: better AWS roles

### DIFF
--- a/lib/services/terraform.js
+++ b/lib/services/terraform.js
@@ -204,7 +204,7 @@ class Terraform {
     terraformDestroy({ name }) {
         const _this = this;
         return new Promise((resolve, reject) => {
-            const tfDestroySpawn = spawn('terraform', ['destroy', '-var-file=terraform.tfvars', '-auto-approve'], {
+            const tfDestroySpawn = spawn('terraform', ['destroy', '-var-file=terraform.tfvars', '-auto-approve', '-refresh'], {
                 cwd: this.targetPath,
             });
 

--- a/resources/terraform/aws/iam-common.tf
+++ b/resources/terraform/aws/iam-common.tf
@@ -1,0 +1,72 @@
+data "aws_iam_policy_document" "swarm_ecr" {
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "swarm_ebs" {
+  statement {
+    actions = [
+      "ec2:AttachVolume",
+      "ec2:CreateVolume",
+      "ec2:CreateSnapshot",
+      "ec2:CreateTags",
+      "ec2:DeleteVolume",
+      "ec2:DeleteSnapshot",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeInstances",
+      "ec2:DescribeVolumes",
+      "ec2:DescribeVolumeAttribute",
+      "ec2:DescribeVolumeStatus",
+      "ec2:DescribeSnapshots",
+      "ec2:CopySnapshot",
+      "ec2:DescribeSnapshotAttribute",
+      "ec2:DetachVolume",
+      "ec2:ModifySnapshotAttribute",
+      "ec2:ModifyVolumeAttribute",
+      "ec2:DescribeTags"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "swarm_detach_role" {
+  statement {
+    actions = [
+      "iam:DetachRolePolicy"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "swarm_ecr" {
+  name   = "orbs-constellation-${var.name}-ecr-policy"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.swarm_ecr.json}"
+}
+
+resource "aws_iam_policy" "swarm_ebs" {
+  name   = "orbs-constellation-${var.name}-ebs-policy"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.swarm_ebs.json}"
+}
+
+resource "aws_iam_policy" "swarm_detach_role_policy" {
+  name   = "orbs-constellation-${var.name}-detach-role-policy"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.swarm_detach_role.json}"
+}
+

--- a/resources/terraform/aws/iam-manager.tf
+++ b/resources/terraform/aws/iam-manager.tf
@@ -1,49 +1,5 @@
 # IAM Role Swarm manager related resources
 
-data "aws_iam_policy_document" "swarm_manager_ecr" {
-  statement {
-    actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage"
-    ]
-
-    resources = ["*"]
-  }
-}
-
-data "aws_iam_policy_document" "swarm_manager_ebs" {
-  statement {
-    actions = [
-      "ec2:AttachVolume",
-      "ec2:CreateVolume",
-      "ec2:CreateSnapshot",
-      "ec2:CreateTags",
-      "ec2:DeleteVolume",
-      "ec2:DeleteSnapshot",
-      "ec2:DescribeAvailabilityZones",
-      "ec2:DescribeInstances",
-      "ec2:DescribeVolumes",
-      "ec2:DescribeVolumeAttribute",
-      "ec2:DescribeVolumeStatus",
-      "ec2:DescribeSnapshots",
-      "ec2:CopySnapshot",
-      "ec2:DescribeSnapshotAttribute",
-      "ec2:DetachVolume",
-      "ec2:ModifySnapshotAttribute",
-      "ec2:ModifyVolumeAttribute",
-      "ec2:DescribeTags"
-    ]
-
-    resources = ["*"]
-  }
-}
-
 data "aws_iam_policy_document" "swarm_manager_secrets" {
   statement {
     actions = [
@@ -81,32 +37,22 @@ resource "aws_iam_policy" "swarm_manager_secrets" {
   policy = "${data.aws_iam_policy_document.swarm_manager_secrets.json}"
 }
 
-resource "aws_iam_policy" "swarm_manager_ecr" {
-  name   = "orbs-constellation-${var.name}-ecr-manager-policy"
-  path   = "/"
-  policy = "${data.aws_iam_policy_document.swarm_manager_ecr.json}"
+resource "aws_iam_role_policy_attachment" "swarm_manager_ecr" {
+  role      = "${aws_iam_role.swarm_manager.name}"
+  policy_arn = "${aws_iam_policy.swarm_ecr.arn}"
 }
 
-resource "aws_iam_policy" "swarm_manager_ebs" {
-  name   = "orbs-constellation-${var.name}-ebs-manager-policy"
-  path   = "/"
-  policy = "${data.aws_iam_policy_document.swarm_manager_ebs.json}"
+resource "aws_iam_role_policy_attachment" "swarm_manager_ebs" {
+  role      = "${aws_iam_role.swarm_manager.name}"
+  policy_arn = "${aws_iam_policy.swarm_ebs.arn}"
 }
 
-resource "aws_iam_policy_attachment" "swarm_manager_ecr" {
-  name       = "swarm-manager-${var.name}-ecr-iam-policy-attachment"
-  roles      = ["${aws_iam_role.swarm_manager.name}"]
-  policy_arn = "${aws_iam_policy.swarm_manager_ecr.arn}"
-}
-
-resource "aws_iam_policy_attachment" "swarm_manager_ebs" {
-  name       = "swarm-manager-${var.name}-ebs-iam-policy-attachment"
-  roles      = ["${aws_iam_role.swarm_manager.name}"]
-  policy_arn = "${aws_iam_policy.swarm_manager_ebs.arn}"
-}
-
-resource "aws_iam_policy_attachment" "swarm_manager_secrets" {
-  name       = "swarm-manager-${var.name}-secrets-iam-policy-attachment"
-  roles      = ["${aws_iam_role.swarm_manager.name}"]
+resource "aws_iam_role_policy_attachment" "swarm_manager_secrets" {
+  role      = "${aws_iam_role.swarm_manager.name}"
   policy_arn = "${aws_iam_policy.swarm_manager_secrets.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "swarm_manager_detach_role" {
+  role      = "${aws_iam_role.swarm_manager.name}"
+  policy_arn = "${aws_iam_policy.swarm_detach_role_policy.arn}"
 }

--- a/resources/terraform/aws/iam-workers.tf
+++ b/resources/terraform/aws/iam-workers.tf
@@ -1,47 +1,4 @@
 # IAM Role resources for swarm workers
-data "aws_iam_policy_document" "swarm_worker_ebs" {
-  statement {
-    actions = [
-      "ec2:AttachVolume",
-      "ec2:CreateVolume",
-      "ec2:CreateSnapshot",
-      "ec2:CreateTags",
-      "ec2:DeleteVolume",
-      "ec2:DeleteSnapshot",
-      "ec2:DescribeAvailabilityZones",
-      "ec2:DescribeInstances",
-      "ec2:DescribeVolumes",
-      "ec2:DescribeVolumeAttribute",
-      "ec2:DescribeVolumeStatus",
-      "ec2:DescribeSnapshots",
-      "ec2:CopySnapshot",
-      "ec2:DescribeSnapshotAttribute",
-      "ec2:DetachVolume",
-      "ec2:ModifySnapshotAttribute",
-      "ec2:ModifyVolumeAttribute",
-      "ec2:DescribeTags"
-    ]
-
-    resources = ["*"]
-  }
-}
-
-data "aws_iam_policy_document" "swarm_worker_ecr" {
-  statement {
-    actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage"
-    ]
-
-    resources = ["*"]
-  }
-}
 
 data "aws_iam_policy_document" "swarm_worker_secrets" {
   statement {
@@ -51,12 +8,6 @@ data "aws_iam_policy_document" "swarm_worker_secrets" {
 
     resources = ["*"]
   }
-}
-
-
-resource "aws_iam_role" "swarm_worker" {
-  name               = "orbs-constellation-${var.name}-worker"
-  assume_role_policy = "${data.aws_iam_policy_document.swarm_role.json}"
 }
 
 data "aws_iam_policy_document" "swarm_role" {
@@ -70,16 +21,14 @@ data "aws_iam_policy_document" "swarm_role" {
   }
 }
 
-resource "aws_iam_policy" "swarm_worker_ebs" {
-  name   = "orbs-constellation-${var.name}-ebs-worker-policy"
-  path   = "/"
-  policy = "${data.aws_iam_policy_document.swarm_worker_ebs.json}"
+resource "aws_iam_role" "swarm_worker" {
+  name               = "orbs-constellation-${var.name}-worker"
+  assume_role_policy = "${data.aws_iam_policy_document.swarm_role.json}"
 }
 
-resource "aws_iam_policy" "swarm_worker_ecr" {
-  name   = "orbs-constellation-${var.name}-ecr-worker-policy"
-  path   = "/"
-  policy = "${data.aws_iam_policy_document.swarm_worker_ecr.json}"
+resource "aws_iam_instance_profile" "swarm_worker" {
+  name = "swarm-worker-${var.name}-profile"
+  role = "${aws_iam_role.swarm_worker.name}"
 }
 
 resource "aws_iam_policy" "swarm_worker_secrets" {
@@ -88,25 +37,22 @@ resource "aws_iam_policy" "swarm_worker_secrets" {
   policy = "${data.aws_iam_policy_document.swarm_worker_secrets.json}"
 }
 
-resource "aws_iam_policy_attachment" "swarm_worker_ebs" {
-  name       = "swarm-worker-${var.name}-ebs-iam-policy-attachment"
-  roles      = ["${aws_iam_role.swarm_worker.name}"]
-  policy_arn = "${aws_iam_policy.swarm_worker_ebs.arn}"
+resource "aws_iam_role_policy_attachment" "swarm_worker_ebs" {
+  role      = "${aws_iam_role.swarm_worker.name}"
+  policy_arn = "${aws_iam_policy.swarm_ebs.arn}"
 }
 
-resource "aws_iam_policy_attachment" "swarm_worker_ecr" {
-  name       = "swarm-worker-${var.name}-ecr-iam-policy-attachment"
-  roles      = ["${aws_iam_role.swarm_worker.name}"]
-  policy_arn = "${aws_iam_policy.swarm_worker_ecr.arn}"
+resource "aws_iam_role_policy_attachment" "swarm_worker_ecr" {
+  role      = "${aws_iam_role.swarm_worker.name}"
+  policy_arn = "${aws_iam_policy.swarm_ecr.arn}"
 }
 
-resource "aws_iam_policy_attachment" "swarm_worker_secrets" {
-  name       = "swarm-worker-${var.name}-secrets-iam-policy-attachment"
-  roles      = ["${aws_iam_role.swarm_worker.name}"]
+resource "aws_iam_role_policy_attachment" "swarm_worker_secrets" {
+  role      = "${aws_iam_role.swarm_worker.name}"
   policy_arn = "${aws_iam_policy.swarm_worker_secrets.arn}"
 }
 
-resource "aws_iam_instance_profile" "swarm_worker" {
-  name = "swarm-worker-${var.name}-profile"
-  role = "${aws_iam_role.swarm_worker.name}"
+resource "aws_iam_role_policy_attachment" "swarm_worker_detach_role" {
+  role      = "${aws_iam_role.swarm_worker.name}"
+  policy_arn = "${aws_iam_policy.swarm_detach_role_policy.arn}"
 }

--- a/resources/terraform/aws/iam-workers.tf
+++ b/resources/terraform/aws/iam-workers.tf
@@ -1,39 +1,7 @@
 # IAM Role resources for swarm workers
-resource "aws_iam_role" "swarm_worker" {
-  name               = "orbs-constellation-${var.name}-worker"
-  assume_role_policy = "${data.aws_iam_policy_document.swarm_role.json}"
-}
-
-data "aws_iam_policy_document" "swarm_role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["ec2.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_policy" "swarm_worker" {
-  name   = "orbs-constellation-${var.name}-worker-policy"
-  path   = "/"
-  policy = "${data.aws_iam_policy_document.swarm_worker.json}"
-}
-
-data "aws_iam_policy_document" "swarm_worker" {
+data "aws_iam_policy_document" "swarm_worker_ebs" {
   statement {
     actions = [
-      "secretsmanager:GetSecretValue",
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "secretsmanager:GetSecretValue",
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
       "ec2:AttachVolume",
       "ec2:CreateVolume",
       "ec2:CreateSnapshot",
@@ -58,10 +26,84 @@ data "aws_iam_policy_document" "swarm_worker" {
   }
 }
 
-resource "aws_iam_policy_attachment" "swarm_worker" {
-  name       = "swarm-worker-${var.name}-iam-policy-attachment"
+data "aws_iam_policy_document" "swarm_worker_ecr" {
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "swarm_worker_secrets" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+
+resource "aws_iam_role" "swarm_worker" {
+  name               = "orbs-constellation-${var.name}-worker"
+  assume_role_policy = "${data.aws_iam_policy_document.swarm_role.json}"
+}
+
+data "aws_iam_policy_document" "swarm_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "swarm_worker_ebs" {
+  name   = "orbs-constellation-${var.name}-ebs-worker-policy"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.swarm_worker_ebs.json}"
+}
+
+resource "aws_iam_policy" "swarm_worker_ecr" {
+  name   = "orbs-constellation-${var.name}-ecr-worker-policy"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.swarm_worker_ecr.json}"
+}
+
+resource "aws_iam_policy" "swarm_worker_secrets" {
+  name   = "orbs-constellation-${var.name}-secrets-worker-policy"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.swarm_worker_secrets.json}"
+}
+
+resource "aws_iam_policy_attachment" "swarm_worker_ebs" {
+  name       = "swarm-worker-${var.name}-ebs-iam-policy-attachment"
   roles      = ["${aws_iam_role.swarm_worker.name}"]
-  policy_arn = "${aws_iam_policy.swarm_worker.arn}"
+  policy_arn = "${aws_iam_policy.swarm_worker_ebs.arn}"
+}
+
+resource "aws_iam_policy_attachment" "swarm_worker_ecr" {
+  name       = "swarm-worker-${var.name}-ecr-iam-policy-attachment"
+  roles      = ["${aws_iam_role.swarm_worker.name}"]
+  policy_arn = "${aws_iam_policy.swarm_worker_ecr.arn}"
+}
+
+resource "aws_iam_policy_attachment" "swarm_worker_secrets" {
+  name       = "swarm-worker-${var.name}-secrets-iam-policy-attachment"
+  roles      = ["${aws_iam_role.swarm_worker.name}"]
+  policy_arn = "${aws_iam_policy.swarm_worker_secrets.arn}"
 }
 
 resource "aws_iam_instance_profile" "swarm_worker" {

--- a/resources/terraform/aws/swarm-manager.tf
+++ b/resources/terraform/aws/swarm-manager.tf
@@ -66,6 +66,12 @@ aws secretsmanager get-secret-value --region ${var.region} --secret-id ${local.s
 
 aws secretsmanager create-secret --region ${var.region} --name swarm-token-${var.name}-worker-${var.region} --secret-string $(docker swarm join-token --quiet worker) || aws secretsmanager put-secret-value --region ${var.region} --secret-id swarm-token-${var.name}-worker-${var.region} --secret-string $(docker swarm join-token --quiet worker)
 
+# Remove access to secrets
+
+aws iam detach-role-policy --role-name orbs-constellation-${var.name}-manager --policy-arn ${aws_iam_policy.swarm_manager_secrets.arn}
+
+# Log into docker hub
+
 $(aws ecr get-login --no-include-email --region us-west-2)
 
 echo '0 * * * * $(/usr/local/bin/aws ecr get-login --no-include-email --region us-west-2)' > /tmp/crontab

--- a/resources/terraform/aws/swarm-manager.tf
+++ b/resources/terraform/aws/swarm-manager.tf
@@ -70,6 +70,8 @@ aws secretsmanager create-secret --region ${var.region} --name swarm-token-${var
 
 aws iam detach-role-policy --role-name orbs-constellation-${var.name}-manager --policy-arn ${aws_iam_policy.swarm_manager_secrets.arn}
 
+aws iam detach-role-policy --role-name orbs-constellation-${var.name}-manager --policy-arn ${aws_iam_policy.swarm_detach_role_policy.arn}
+
 # Log into docker hub
 
 $(aws ecr get-login --no-include-email --region us-west-2)

--- a/resources/terraform/aws/swarm-workers.tf
+++ b/resources/terraform/aws/swarm-workers.tf
@@ -49,6 +49,10 @@ while true; do
     sleep 5
 done
 
+# Remove access to secrets
+
+aws iam detach-role-policy --role-name orbs-constellation-${var.name}-worker --policy-arn ${aws_iam_policy.swarm_worker_secrets.arn}
+
 TFEOF
 }
 

--- a/resources/terraform/aws/swarm-workers.tf
+++ b/resources/terraform/aws/swarm-workers.tf
@@ -53,6 +53,8 @@ done
 
 aws iam detach-role-policy --role-name orbs-constellation-${var.name}-worker --policy-arn ${aws_iam_policy.swarm_worker_secrets.arn}
 
+aws iam detach-role-policy --role-name orbs-constellation-${var.name}-worker --policy-arn ${aws_iam_policy.swarm_detach_role_policy.arn}
+
 TFEOF
 }
 


### PR DESCRIPTION
Currently we have numerous issues with security and it is far from perfect. There are lots of things needed to be addressed. Sometimes it is difficult to separate deployment security from the security of the node binary itself.

We keep private keys in secrets storage in AWS and they are stored there indefinitely.

Secrets permission give access to all and any secrets on the account.

To mitigate this, the best solution that I have found was this:
- [x] Split manager and worker roles into multiple policies
- [x] Detach all policies except ECR and EBS access after the node has been bootstrapped

It means that the node (and all the containers running on it) automatically loses any access to the node keys and SSL certificates. This significantly boosts security if someone would break into a virtual chain container.
