### PR TITLE
Eliminate race condition on worker nodes

### DIFF
--- a/resources/terraform/aws/iam-workers.tf
+++ b/resources/terraform/aws/iam-workers.tf
@@ -51,8 +51,3 @@ resource "aws_iam_role_policy_attachment" "swarm_worker_secrets" {
   role      = "${aws_iam_role.swarm_worker.name}"
   policy_arn = "${aws_iam_policy.swarm_worker_secrets.arn}"
 }
-
-resource "aws_iam_role_policy_attachment" "swarm_worker_detach_role" {
-  role      = "${aws_iam_role.swarm_worker.name}"
-  policy_arn = "${aws_iam_policy.swarm_detach_role_policy.arn}"
-}

--- a/resources/terraform/aws/swarm-manager.tf
+++ b/resources/terraform/aws/swarm-manager.tf
@@ -85,6 +85,10 @@ while true; do
     sleep 15
 done
 
+# Remove access to worker secrets
+
+aws iam detach-role-policy --role-name orbs-constellation-${var.name}-worker --policy-arn ${aws_iam_policy.swarm_worker_secrets.arn}
+
 # Label workers
 for n in $(docker node ls --format '{{.ID}} {{.ManagerStatus}}' | grep -v Leader | cut -d" " -f1); do
     docker node update --label-add worker=true $n

--- a/resources/terraform/aws/swarm-workers.tf
+++ b/resources/terraform/aws/swarm-workers.tf
@@ -49,12 +49,6 @@ while true; do
     sleep 5
 done
 
-# Remove access to secrets
-
-aws iam detach-role-policy --role-name orbs-constellation-${var.name}-worker --policy-arn ${aws_iam_policy.swarm_worker_secrets.arn}
-
-aws iam detach-role-policy --role-name orbs-constellation-${var.name}-worker --policy-arn ${aws_iam_policy.swarm_detach_role_policy.arn}
-
 TFEOF
 }
 


### PR DESCRIPTION
Worker nodes used to detach a policy from its role that granted it access to aws secretsmanager. It would lead to a race condition if there was more than 1 worker node.

Now the detachment happens on manager node after all workers have joined the swarm.