### PR TITLE
update security groups and increase disk size

### DIFF
--- a/lib/cli/handlers/create.js
+++ b/lib/cli/handlers/create.js
@@ -21,7 +21,7 @@ function _create({ fileMode = false, __fileDirname = '', awsProfile, sshPublicKe
 
     // Expand cache path
     if (cachePath !== undefined) {
-        cachePath = resolvePath(cachePath, fileMode? __fileDirname : process.cwd());
+        cachePath = resolvePath(cachePath, fileMode ? __fileDirname : process.cwd());
     } else {
         cachePath = resolvePath("~/.nebula");
     }
@@ -43,11 +43,11 @@ function _create({ fileMode = false, __fileDirname = '', awsProfile, sshPublicKe
     }
 
     if (!_.isEmpty(sslCertificatePath)) {
-        sslCertificatePath = resolvePath(sslCertificatePath);
+        sslCertificatePath = resolvePath(sslCertificatePath, __fileDirname);
     }
 
     if (!_.isEmpty(sslPrivateKeyPath)) {
-        sslPrivateKeyPath = resolvePath(sslPrivateKeyPath);
+        sslPrivateKeyPath = resolvePath(sslPrivateKeyPath, __fileDirname);
     }
 
     if (orbsAddress.length !== 40) {

--- a/resources/terraform/aws/security-groups.tf
+++ b/resources/terraform/aws/security-groups.tf
@@ -33,22 +33,13 @@ resource "aws_security_group" "swarm" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  // Http ports
-  ingress {
-    from_port   = 8000
-    to_port     = 8999
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  // Gossip ports
+  // http & gossip ports (tcp)
   ingress {
     from_port   = 4000
-    to_port     = 4999
+    to_port     = 20000
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
 
   // All outbound traffic from any port
   egress {

--- a/resources/terraform/aws/swarm-manager.tf
+++ b/resources/terraform/aws/swarm-manager.tf
@@ -131,7 +131,7 @@ resource "aws_instance" "manager" {
 }
 
 resource "aws_ebs_volume" "manager_storage" {
-  size = 30
+  size = 50
   availability_zone = "${aws_instance.manager.availability_zone}"
 
   tags = {


### PR DESCRIPTION
The security rules in terms of tcp ports for gossip or http are not sufficient

This is a lesson learned from dynamically spawning virtual chains on the Orbs testnet and therefore I propose this PR to eliminate any port issues and increase the range of tcp ports which are allowed to assign via Boyar for any particular chain.