### PR TITLE
Add more logs visibility and uptime assurances (Supervisor)

### DIFF
--- a/lib/cli/handlers/create.js
+++ b/lib/cli/handlers/create.js
@@ -28,7 +28,8 @@ function _create({ fileMode = false, __fileDirname = '', awsProfile, sshPublicKe
 
     // Expand SSH public key path
     if (fileMode) {
-        sshPublicKey = resolvePath(sshPublicKey, __fileDirname);
+        //sshPublicKey = resolvePath(sshPublicKey, __fileDirname); @todo - remember why this (__fileDirname) is here
+        sshPublicKey = resolvePath(sshPublicKey);
     }
 
     if (!_.isEmpty(configPath)) {

--- a/lib/cli/handlers/create.js
+++ b/lib/cli/handlers/create.js
@@ -21,7 +21,7 @@ function _create({ fileMode = false, __fileDirname = '', awsProfile, sshPublicKe
 
     // Expand cache path
     if (cachePath !== undefined) {
-        cachePath = resolvePath(cachePath, fileMode? __fileDirname : process.cwd());
+        cachePath = resolvePath(cachePath, fileMode ? __fileDirname : process.cwd());
     } else {
         cachePath = resolvePath("~/.nebula");
     }
@@ -43,11 +43,11 @@ function _create({ fileMode = false, __fileDirname = '', awsProfile, sshPublicKe
     }
 
     if (!_.isEmpty(sslCertificatePath)) {
-        sslCertificatePath = resolvePath(sslCertificatePath);
+        sslCertificatePath = resolvePath(sslCertificatePath, __fileDirname);
     }
 
     if (!_.isEmpty(sslPrivateKeyPath)) {
-        sslPrivateKeyPath = resolvePath(sslPrivateKeyPath);
+        sslPrivateKeyPath = resolvePath(sslPrivateKeyPath, __fileDirname);
     }
 
     if (orbsAddress.length !== 40) {

--- a/lib/cli/handlers/create.js
+++ b/lib/cli/handlers/create.js
@@ -44,7 +44,8 @@ function _create({ fileMode = false, __fileDirname = '', awsProfile, sshPublicKe
     }
 
     if (!_.isEmpty(sslCertificatePath)) {
-        sslCertificatePath = resolvePath(sslCertificatePath, __fileDirname);
+        //sslCertificatePath = resolvePath(sslCertificatePath, __fileDirname);  @todo - remember why this (__fileDirname) is here
+        sslCertificatePath = resolvePath(sslCertificatePath);
     }
 
     if (!_.isEmpty(sslPrivateKeyPath)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbs-network/orbs-nebula",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Nebula is a tool to provision new Orbs Hybrid Blockchain Constellations",
   "main": "index.js",
   "scripts": {

--- a/resources/terraform/aws/security-groups.tf
+++ b/resources/terraform/aws/security-groups.tf
@@ -33,22 +33,13 @@ resource "aws_security_group" "swarm" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  // Http ports
-  ingress {
-    from_port   = 8000
-    to_port     = 8999
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  // Gossip ports
+  // http & gossip ports (tcp)
   ingress {
     from_port   = 4000
-    to_port     = 4999
+    to_port     = 20000
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
 
   // All outbound traffic from any port
   egress {

--- a/resources/terraform/aws/swarm-manager.tf
+++ b/resources/terraform/aws/swarm-manager.tf
@@ -131,7 +131,7 @@ resource "aws_instance" "manager" {
 }
 
 resource "aws_ebs_volume" "manager_storage" {
-  size = 30
+  size = 50
   availability_zone = "${aws_instance.manager.availability_zone}"
 
   tags = {

--- a/resources/terraform/aws/swarm-manager.tf
+++ b/resources/terraform/aws/swarm-manager.tf
@@ -115,7 +115,7 @@ if [ ! -z "$(cat $SSL_CERT_PATH)" ] && [ ! -z "$(cat $SSL_PRIVATE_KEY_PATH)" ]; 
 fi
 
 # Boostrap everything with Boyar
-HOME=/root nohup boyar --log /var/log/boyar.log --config-url ${var.s3_boyar_config_url} --keys /opt/orbs/keys.json --daemonize --max-reload-time-delay 0m $ETHEREUM_PARAMS $SSL_PARAMS &
+HOME=/root nohup boyar --logger-http-endpoint "https://listener.logz.io:8071/?token=kATbDvYGTXTOOfyvDYGbWrGdIFBPpvHI&type=prod" --config-url ${var.s3_boyar_config_url} --keys /opt/orbs/keys.json --daemonize --max-reload-time-delay 0m $ETHEREUM_PARAMS $SSL_PARAMS & > /var/log/boyar.log
 
 TFEOF
 }

--- a/resources/terraform/aws/variables.tf
+++ b/resources/terraform/aws/variables.tf
@@ -55,6 +55,10 @@ variable "ethereum_endpoint" {
   default = ""
 }
 
+variable "logz_io_http_endpoint" {
+  default = "https://listener.logz.io:8071/?token=kATbDvYGTXTOOfyvDYGbWrGdIFBPpvHI&type=prod"
+}
+
 variable "boyar_version" {
   default = "v0.20.0"
 }
@@ -70,4 +74,8 @@ variable "ssl_certificate" {
 
 variable "ssl_private_key" {
   default = "Cg=="
+}
+
+variable "node_exporter_version" {
+  default = "0.18.1"
 }


### PR DESCRIPTION
This PR adds to the provisioned server a change to the way Boyar is configured on top of the manager node by giving it an http endpoint of logz.io to report it's logs to. 

These logs are crucial and provide "eyes" for the core team to view the registered Docker services (aka clustered containers) that the Docker swarm cluster manages which are essentially our virtual chains containers in each node.

In addition, protection against a premature death of the Boyar process has been added in the shape of Supervisor (a simple and popular process manager for Linux)

While we are making stuff visible for Boyar, we decided to also add visibility of the Swarm manager  host machine as well by using the Node exporter lightweight Go agent  by Prometheus which you can read more about by [https://prometheus.io/docs/guides/node-exporter/](clicking here)

The exporter itself is exposed at port 9100 on the manager node and provides valuable metrics from the host machine. These metrics would later on be collected by our Prometheus server to provide more visiblity into the manager node health condition.