### PR TITLE
efsId is now a shared state artifact inside S3

### DIFF
--- a/lib/services/nebula.js
+++ b/lib/services/nebula.js
@@ -7,7 +7,7 @@ const AWS = require('aws-sdk');
 
 class Nebula {
     constructor({ terraformAdapter = null, awsAdapter = AWS }) {
-        if (!terraformAdapter){
+        if (!terraformAdapter) {
             throw new Error('No Terraform adapter provided!');
         }
         this.terraform = terraformAdapter;
@@ -70,6 +70,37 @@ class Nebula {
         });
     }
 
+    async restoreEFSIdFromStateBucket({ region, name }) {
+        const Bucket = this.getTerraformStateStoragePreparedBucketName({ region, name });
+        this.aws.config.update({ region });
+
+        const result = await this.s3
+            .getObject({
+                Bucket,
+                Key: 'storage/.efs',
+            })
+            .promise();
+
+        return result.Body.toString(); // -> efsId
+    }
+
+    saveEFSIdIntoStateBucket({ region, name, efsId }) {
+        const Bucket = this.getTerraformStateStoragePreparedBucketName({ region, name });
+        this.aws.config.update({ region });
+
+        return new Promise((resolve, reject) => {
+            this.s3.putObject({
+                Bucket,
+                Key: 'storage/.efs',
+                Body: efsId,
+                ACL: 'public-read'
+            }, function (err) {
+                if (err) { reject({ err }); }
+                resolve({ ok: true });
+            });
+        });
+    }
+
     getTerraformStateStoragePreparedBucketName({ region, name }) {
         return `orbs-${region}-${name}`;
     }
@@ -83,10 +114,10 @@ class Nebula {
 
             this.s3.listObjectsV2(params, function (err, data) {
                 if (err) {
-                    console.log(err, err.stack); // an error occurred
+                    //console.log(err, err.stack); // an error occurred
                     reject(err);
                 } else {
-                    console.log('bucket contents:', data);
+                    // console.log('bucket contents:', data);
                     resolve(data);
                 }
             });
@@ -111,7 +142,7 @@ class Nebula {
 
             this.s3.deleteObjects(params, function (err, data) {
                 if (err) {
-                    console.log(err, err.stack); // an error occurred
+                    // console.log(err, err.stack); // an error occurred
                     reject(err);
                 } else {
                     resolve(data);
@@ -129,7 +160,7 @@ class Nebula {
 
             this.s3.deleteBucket(params, function (err, data) {
                 if (err) {
-                    console.log(err, err.stack); // an error occurred
+                    //console.log(err, err.stack); // an error occurred
                     reject(err);
                     return;
                 }
@@ -155,6 +186,12 @@ class Nebula {
             let params = { region: cloud.region, name: cloud.name };
             try {
                 await this.terraformStateStorageBucketExists(params);
+                // After the bucket thing is settled, we should workout if an EFS exists for this node.
+
+                const efsId = await this.restoreEFSIdFromStateBucket(params);
+                // Enrich the cloud object with the efsId
+
+                cloud.efsId = efsId;
             } catch (err) {
                 if (err.message === 'No state bucket found') {
                     console.log('error message correct');
@@ -175,6 +212,9 @@ class Nebula {
 
         const { outputs } = result;
 
+        const efsId = outputs[outputs.findIndex(o => o.key === 'block_storage')].value;
+        await this.saveEFSIdIntoStateBucket({ region: cloud.region, name: cloud.name, efsId });
+
         const swarmmanagerPublicIp = (eip) ? cloud.ip :
             outputs.find(o => o.key === 'manager_ip').value;
 
@@ -193,23 +233,32 @@ class Nebula {
             return result;
         }
 
-        const result = await this.terraform.destroy({ cloud, keys });
+        let destroyBucket = false;
+        let params = {
+            region: cloud.region,
+            name: cloud.name,
+        };
 
         if (cloud.backend) {
-            let params = {
-                region: cloud.region,
-                name: cloud.name,
-            };
-
             try {
                 await this.terraformStateStorageBucketExists(params);
-                // If we pass this line without throwing an error
-                // We can safely assert from that the bucket exists and we should destroy it.
-                // To keep the validator's AWS account sparkly clean!
+                destroyBucket = true;
+                const efsId = await this.restoreEFSIdFromStateBucket(params);
+                // Enrich the cloud object with the efsId
 
+                cloud.efsId = efsId;
+            } catch (err) {
+                // Swallow the error on purpose.
+            }
+        }
+
+        const result = await this.terraform.destroy({ cloud, keys });
+
+        if (cloud.backend && destroyBucket) {
+            try {
                 await this.terraformStateStorageDeleteBucket(params);
             } catch (err) {
-                console.log('No terraform state bucket, skipping destruction of it.', err);
+                console.log('State bucket failed to destroy', err);
             }
         }
 

--- a/lib/services/terraform.js
+++ b/lib/services/terraform.js
@@ -64,6 +64,10 @@ class Terraform {
             }
         }
 
+        if (cloud.efsId) {
+            fs.writeFileSync(path.join(this.targetPath, '.efs'), cloud.efsId);
+        }
+
         if (!cloud.backend) {
             await exec(`rm -f ${path.join(this.targetPath, 'backend.tf')}`);
         } else {
@@ -164,6 +168,7 @@ class Terraform {
 
             this.spinner.succeed();
             this.spinner.start(`Terraform initialize`);
+
             await this.init({ cloud });
             this.spinner.succeed();
 
@@ -262,7 +267,7 @@ class Terraform {
         return new Promise((resolve, reject) => {
             tfProcess.on('close', (code) => {
                 if (code === 0) {
-                    resolve({code, outputs: getOutputs()});
+                    resolve({ code, outputs: getOutputs() });
                 } else {
                     this.spinner.fail();
                     console.log('');


### PR DESCRIPTION
This PR introduces a fix to the EFS drive being provisioned by Nebula so that it's Id (incase it already exists) will be restored from the shared state bucket (S3) incase Nebula has ran but the local state got lost (wiped out/deleted/any other disaster)

The feature was developed by @netoneko orthogonaly to the shared state feature thus not having to take this into account, assuming Nebula users are not to delete their state.

This is now addressed in the shape of this PR